### PR TITLE
Header/Footer: add missing wp_head() for auto title

### DIFF
--- a/header.php
+++ b/header.php
@@ -4,7 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?php bloginfo("name") ?></title>
-    <?php wp_head() ?>
 </head>
 <body>
     <header>


### PR DESCRIPTION
This PR ensures wp_head() is added to header.php so WordPress can output dynamic <title> tags and enqueued scripts/styles properly. Also verify wp_footer() before </body> for footer hooks.