### PR TITLE
In feature/HeaderFooter the Wordpress auto-title function is enabled, but wp_head() is not placed in header.php

### DIFF
--- a/header.php
+++ b/header.php
@@ -4,7 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?php bloginfo("name") ?></title>
-    <?php wp_head() ?>
 </head>
 <body>
     <header>


### PR DESCRIPTION
Request:
Add <?php wp_head(); ?> in header.php just before the closing </head> tag.

Rationale:
Without wp_head(), WordPress cannot inject essential scripts, styles, and meta data. This can break plugins, themes, and SEO functionality, since many rely on this hook to load assets correctly.

Result:
Your header.php will allow WordPress and plugins to function as intended. Example:

<head>
  <meta charset="<?php bloginfo( 'charset' ); ?>">
  <title><?php wp_title(); ?></title>
  <?php wp_head(); ?>
</head>